### PR TITLE
Merging changes to solve the issue of mocking the delays

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,20 @@
+
+
+//We have sepreate consts and enums for the puporse of being used during
+//testing(consts) or as parameters(enum).
+pub const READ_STATUS: u8 = 0x71;
+pub const INIT_SENSOR: u8 = 0xBE;
+pub const CALIBRATE: u8 = 0xE1;
+pub const TRIG_MESSURE: u8 = 0xAC;
+pub const SOFT_RESET: u8 = 0xBA;
+
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum Command {
+    ReadStatus = READ_STATUS,
+    InitSensor = INIT_SENSOR,
+    Calibrate = CALIBRATE,
+    TrigMessure = TRIG_MESSURE,
+    SoftReset = SOFT_RESET,
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,13 +116,6 @@ mod sensor_test {
     use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTransaction};
     use super::*;
 
-//    fn initialized_sensor_setup(expected: &[I2cTransaction]) -> InitializedSensor<'a, I2C> {
-//        //Skip doing the INIT of the sensor.
-//        let i2c = I2cMock::new(expected);
-//        let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
-//        InitializedSensor {sensor: &mut sensor_instance}
-//    }
-
     #[test]
     fn self_test()
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,56 @@ mod test_bitmaks {
     }
 }
 
+#[allow(dead_code)]
+pub struct SensorStatus {
+    status: u8,
+}
+
+#[allow(dead_code)]
+impl SensorStatus{
+    fn is_busy(&self) -> bool {
+        true    
+    }
+
+    fn is_calibration_enabled(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod sensor_status_tests {
+    use super::*;
+
+    #[test]
+    fn busy_status() {
+        let mut senstat = SensorStatus {status: 0x00};
+        assert_eq!(senstat.status, 0x00);
+
+        assert!(!senstat.is_busy());
+
+        senstat.status |= StatusBitMasks::Busy as u8;
+        assert!(senstat.is_busy());
+
+        senstat.status |= StatusBitMasks::CalEnabled as u8;
+        assert!(senstat.is_busy());
+    }
+
+    #[test]
+    fn calibration_status() {
+    
+        let mut senstat = SensorStatus {status: 0x00};
+        assert_eq!(senstat.status, 0x00);
+
+        assert!(!senstat.is_calibration_enabled());
+
+        senstat.status |= StatusBitMasks::CalEnabled as u8;
+        assert!(senstat.is_calibration_enabled());
+
+        senstat.status |= StatusBitMasks::Busy as u8;
+        assert!(senstat.is_calibration_enabled());
+    }
+}
+
 //Impliment Error type for our driver.
 #[derive(Debug, PartialEq)]
 pub enum Error<E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ use embedded_hal::blocking::i2c;
 //Import the module with the Sensor status functions/struct
 mod sensor_status;
 
+//Import the sensor's availble i2c commands and variables
+mod commands;
+use crate::commands::Command;
 
 /// AHT20 Sensor Address
 pub const SENSOR_ADDR: u8 = 0b0011_1000; // = 0x38
@@ -20,16 +23,6 @@ pub const STARTUP_DELAY_MS: u8 = 40;
 
 
 
-//Bits and their meanings Check the datasheet for version 1.1
-//URL: www.aosong.com
-/*
- * bit[7]: Busy
- * bit[6:5]: 00: NOR mode, 01: CYC mode, 1x: CMD mode 
- * bit[4]: Reserved
- * bit[3]: CAL Enable
- * bit[2:0]: Reserved
-*/
-
 //Impliment Error type for our driver.
 #[derive(Debug, PartialEq)]
 pub enum Error<E> {
@@ -37,24 +30,6 @@ pub enum Error<E> {
     InvalidChecksum,
     UnexpectedBusy,
     Internal,
-}
-
-
-//We have sepreate consts and enums for the puporse of being used during
-//testing(consts) or as parameters(enum).
-const CMD_READ_STATUS: u8 = 0x71;
-const CMD_INIT_SENSOR: u8 = 0xBE;
-const CMD_CALIBRATE: u8 = 0xE1;
-const CMD_TRIG_MESSURE: u8 = 0xAC;
-const CMD_SOFT_RESET: u8 = 0xBA;
-
-#[repr(u8)]
-pub enum Command {
-    ReadStatus = CMD_READ_STATUS,
-    InitSensor = CMD_INIT_SENSOR,
-    Calibrate = CMD_CALIBRATE,
-    TrigMessure = CMD_TRIG_MESSURE,
-    SoftReset = CMD_SOFT_RESET,
 }
 
 
@@ -176,7 +151,7 @@ mod sensor_test {
     fn correct_init()
     {
         let expectations = [
-            I2cTransaction::write(SENSOR_ADDR, vec![CMD_INIT_SENSOR]),
+            I2cTransaction::write(SENSOR_ADDR, vec![Command::InitSensor as u8]),
         ];
         
         let i2c = I2cMock::new(&expectations);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,21 +85,21 @@ where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
     }
 
     pub fn get_status(&mut self) -> Result< u8, Error<E> >{ 
-        let write_buf = vec![Command::ReadStatus as u8];
         
         self.clear_buf();
+        self.sensor.buffer[0] = Command::ReadStatus as u8;
 
         let _write_result = self.sensor.i2c 
-            .write(SENSOR_ADDR, &write_buf)
-            .map_err(Error::I2C)?;
- 
-        let mut read_buf  = [0 as u8];
-        
-        let _read_result = self.sensor.i2c 
-            .read(SENSOR_ADDR, &mut read_buf)
+            .write(SENSOR_ADDR, &self.sensor.buffer)
             .map_err(Error::I2C)?;
 
-        let status = read_buf[0];
+        self.clear_buf();
+        
+        let _read_result = self.sensor.i2c 
+            .read(SENSOR_ADDR, &mut self.sensor.buffer)
+            .map_err(Error::I2C)?;
+
+        let status = self.sensor.buffer[0]; 
         Ok(status)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,15 +80,19 @@ impl <'a, E, I2C> InitializedSensor<'a, I2C>
 where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
 {
 
-    pub fn check_status(&mut self) -> Result< u8, Error<E> >{ 
+    fn clear_buf(&mut self) {
+        self.sensor.buffer.map(|mut _x|{ _x = 0});
+    }
 
+    pub fn get_status(&mut self) -> Result< u8, Error<E> >{ 
         let write_buf = vec![Command::ReadStatus as u8];
         
+        self.clear_buf();
+
         let _write_result = self.sensor.i2c 
             .write(SENSOR_ADDR, &write_buf)
             .map_err(Error::I2C)?;
-
-        
+ 
         let mut read_buf  = [0 as u8];
         
         let _read_result = self.sensor.i2c 
@@ -157,7 +161,7 @@ mod sensor_test {
     }
 
     #[test]
-    fn check_status()
+    fn get_status()
     {
         let sensor_status= vec![
             sensor_status::BitMasks::CmdMode as u8 | 
@@ -174,7 +178,7 @@ mod sensor_test {
         let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
         let mut inited_sensor = InitializedSensor {sensor: &mut sensor_instance}; 
        
-        let _r = inited_sensor.check_status();
+        let _r = inited_sensor.get_status();
 
         inited_sensor.sensor.i2c.done();
     }
@@ -206,7 +210,7 @@ mod sensor_test {
         let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
         let mut inited_sensor = InitializedSensor {sensor: &mut sensor_instance}; 
        
-        let _r = inited_sensor.check_status();
+        let _r = inited_sensor.get_status();
 
         inited_sensor.sensor.i2c.done();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
 
         //check if the status is good.
         let mut status = self.read_status()?;
-        for _i in 2..MAX_STATUS_CHECK_ATTEMPTS {
+        for _i in 0..MAX_STATUS_CHECK_ATTEMPTS {
             if (status & (sensor_status::BitMasks::Busy as u8)) != 0 {
                 delay.delay_ms(BUSY_DELAY_MS); 
                 status = self.read_status()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #[macro_use]
 extern crate alloc;
 
-//use embedded_hal::blocking::delay::{DelayMs, DelayUs};
-//use embedded_hal::blocking::i2c;
 use embedded_hal::blocking::{
     i2c,
     delay::DelayMs,
@@ -35,6 +33,7 @@ pub enum Error<E> {
     InvalidChecksum,
     UnexpectedBusy,
     Internal,
+    DeviceTimeOut
 }
 
 
@@ -82,7 +81,7 @@ where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
                 return Ok(InitializedSensor {sensor: self});
             }
         }
-        Err(Error::UnexpectedBusy)
+        Err(Error::DeviceTimeOut)
     }
 
 
@@ -339,9 +338,10 @@ mod sensor_test {
  
         let mut mock_delay = delay::MockNoop;
         let initialized_sensor_instance = sensor_instance.init(&mut mock_delay);       
-        
+       
         assert!(initialized_sensor_instance.is_err());
     }
+
 
     #[test]
     fn get_initialized_status()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,14 @@ mod sensor_status;
 mod commands;
 use crate::commands::Command;
 
+
+
+
 /// AHT20 Sensor Address
 pub const SENSOR_ADDR: u8 = 0b0011_1000; // = 0x38
 
-
-//Minimum startup wait time.
 pub const STARTUP_DELAY_MS: u8 = 40;
-
+pub const BUSY_DELAY_MS: u8 = 20;
 
 
 //Impliment Error type for our driver.
@@ -42,16 +43,6 @@ where I2C: i2c::Read + i2c::Write,
     buffer: [u8; 4],
 }
 
-//This stucture encapsulates the Sensor structure after the sensor
-//has been initialized; enforcing correct method availbility.
-#[allow(dead_code)]
-pub struct InitializedSensor<'a, I2C>
-where I2C: i2c::Read + i2c::Write,
-{
-    sensor: &'a mut Sensor<I2C>,
-}
-
-
 //Impliment functions for the sensor that require the embedded-hal
 //I2C.
 impl<E, I2C> Sensor<I2C>
@@ -71,6 +62,16 @@ where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
 
         Ok(InitializedSensor {sensor: self})
     }
+}
+
+
+//This stucture encapsulates the Sensor structure after the sensor
+//has been initialized; enforcing correct method availbility.
+#[allow(dead_code)]
+pub struct InitializedSensor<'a, I2C>
+where I2C: i2c::Read + i2c::Write,
+{
+    sensor: &'a mut Sensor<I2C>,
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,8 @@ where I2C: i2c::Read<Error = E> + i2c::Write<Error = E>,
                 return Ok(InitializedSensor {sensor: self});
             }
         }
-        Err(Error::DeviceTimeOut)
+        return Err(Error::DeviceTimeOut);
     }
-
 
     pub fn read_status(&mut self) -> Result<u8, Error<E>>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,17 @@ pub struct SensorStatus {
 #[allow(dead_code)]
 impl SensorStatus{
     fn is_busy(&self) -> bool {
-        true    
+        if self.status & StatusBitMasks::Busy as u8 > 0 {
+            return true;
+        }
+        return false;
     }
 
     fn is_calibration_enabled(&self) -> bool {
-        true
+        if self.status & StatusBitMasks::CalEnabled as u8 > 0 {
+            return true
+        }
+        return false 
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,12 @@ mod sensor_test {
     }
 
     #[test]
+    fn timed_out_init()
+    {
+        assert!(false);
+    }
+
+    #[test]
     fn get_status()
     {
         let sensor_status= vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,12 @@ mod sensor_test {
 
     //use embedded_hal::prelude::*;
     use embedded_hal::blocking::i2c::{Read, Write};
-    use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTransaction};
+    
+    use embedded_hal_mock::i2c::{
+        Mock as I2cMock, 
+        Transaction as I2cTransaction
+    };
+    
     use super::*;
 
     #[test]
@@ -153,7 +158,10 @@ mod sensor_test {
     fn correct_init()
     {
         let expectations = [
-            I2cTransaction::write(SENSOR_ADDR, vec![Command::InitSensor as u8]),
+            I2cTransaction::write(
+                SENSOR_ADDR, 
+                vec![Command::InitSensor as u8]
+                ),
         ];
         
         let i2c = I2cMock::new(&expectations);
@@ -180,7 +188,9 @@ mod sensor_test {
         //Skip doing the INIT of the sensor.
         let i2c = I2cMock::new(&expected);
         let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
-        let mut inited_sensor = InitializedSensor {sensor: &mut sensor_instance}; 
+        let mut inited_sensor = InitializedSensor {
+            sensor: &mut sensor_instance
+        }; 
        
         let _r = inited_sensor.get_status();
 
@@ -212,7 +222,9 @@ mod sensor_test {
         //Skip doing the INIT of the sensor.
         let i2c = I2cMock::new(&expected);
         let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
-        let mut inited_sensor = InitializedSensor {sensor: &mut sensor_instance}; 
+        let mut inited_sensor = InitializedSensor {
+            sensor: &mut sensor_instance
+        }; 
        
         let _r = inited_sensor.get_status();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,47 @@ mod sensor_test {
     #[test]
     fn timed_out_init()
     {
-        assert!(false);
+
+        let busy_status: u8 = sensor_status::BitMasks::Busy as u8;
+
+        let expectations = [
+            I2cTransaction::write(
+                SENSOR_ADDR,
+                vec![Command::InitSensor as u8]
+                ),
+            I2cTransaction::write(
+                SENSOR_ADDR, 
+                vec![Command::ReadStatus as u8]
+                ),
+            I2cTransaction::read(SENSOR_ADDR, vec![busy_status]),
+
+            I2cTransaction::write(
+                SENSOR_ADDR, 
+                vec![Command::ReadStatus as u8]
+                ),
+            I2cTransaction::read(SENSOR_ADDR, vec![busy_status]),
+
+            I2cTransaction::write(
+                SENSOR_ADDR, 
+                vec![Command::ReadStatus as u8]
+                ),
+            I2cTransaction::read(SENSOR_ADDR, vec![busy_status]),
+
+            I2cTransaction::write(
+                SENSOR_ADDR, 
+                vec![Command::ReadStatus as u8]
+                ),
+            I2cTransaction::read(SENSOR_ADDR, vec![busy_status]),
+        ];
+
+
+        let i2c = I2cMock::new(&expectations);
+        let mut sensor_instance = Sensor::new(i2c, SENSOR_ADDR);
+ 
+        let mut mock_delay = delay::MockNoop;
+        let initialized_sensor_instance = sensor_instance.init(&mut mock_delay);       
+        
+        assert!(initialized_sensor_instance.is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,6 @@ mod sensor_status;
 /// AHT20 Sensor Address
 pub const SENSOR_ADDR: u8 = 0b0011_1000; // = 0x38
 
-//Seventh bit indicates read/write                                        
-pub const READ_MSK: u8 = 1<<0;        
-pub const WRITE_MSK: u8 = 0<<0;
 
 //Minimum startup wait time.
 pub const STARTUP_DELAY_MS: u8 = 40;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,19 +218,3 @@ mod sensor_test {
     }
 }
 
-
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/sensor_status.rs
+++ b/src/sensor_status.rs
@@ -1,0 +1,98 @@
+
+//This means it's a primitive enum representation; aka uint8_t
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum BitMasks {
+    Busy = (1 << 7),
+    NorMode = ((0 << 6) |( 0 << 5)),
+    CycMode = ((0 << 6) |( 1 << 5)),
+    CmdMode = (1 << 6),
+    CalEnabled = (1 << 3),
+}
+
+#[cfg(test)]
+mod test_bitmaks {
+    use super::*;
+
+    #[test]
+    fn check_busy() {
+        assert_eq!(BitMasks::Busy as u8, 128);
+    }
+    
+    #[test]
+    fn check_modes() {
+        assert_eq!(BitMasks::NorMode as u8, 0);
+        assert_eq!(BitMasks::CycMode as u8, 32);
+        assert_eq!(BitMasks::CmdMode as u8, 64);
+
+    }
+
+    #[test]
+    fn check_combined() {
+
+        assert_eq!(
+                BitMasks::CmdMode as u8 |
+                BitMasks::Busy as u8,
+                128 + 64
+            );
+    }
+}
+
+#[allow(dead_code)]
+pub struct SensorStatus {
+    status: u8,
+}
+
+#[allow(dead_code)]
+impl SensorStatus{
+    pub fn is_busy(&self) -> bool {
+        if self.status & BitMasks::Busy as u8 > 0 {
+            return true;
+        }
+        return false;
+    }
+
+    pub fn is_calibration_enabled(&self) -> bool {
+        if self.status & BitMasks::CalEnabled as u8 > 0 {
+            return true
+        }
+        return false 
+    }
+}
+
+#[cfg(test)]
+mod sensor_status_tests {
+    use super::*;
+
+    #[test]
+    fn busy_status() {
+        let mut senstat = SensorStatus {status: 0x00};
+        assert_eq!(senstat.status, 0x00);
+
+        assert!(!senstat.is_busy());
+
+        //set the busy bit.
+        senstat.status |= BitMasks::Busy as u8;
+        assert!(senstat.is_busy());
+
+        senstat.status |= BitMasks::CalEnabled as u8;
+        assert!(senstat.is_busy());
+    }
+
+    #[test]
+    fn calibration_status() {
+    
+        let mut senstat = SensorStatus {status: 0x00};
+        assert_eq!(senstat.status, 0x00);
+
+        assert!(!senstat.is_calibration_enabled());
+
+        //set the calibration bit
+        senstat.status |= BitMasks::CalEnabled as u8;
+        assert!(senstat.is_calibration_enabled());
+
+        senstat.status |= BitMasks::Busy as u8;
+        assert!(senstat.is_calibration_enabled());
+    }
+}
+

--- a/src/sensor_status.rs
+++ b/src/sensor_status.rs
@@ -1,3 +1,12 @@
+//Bits and their meanings Check the datasheet for version 1.1
+//URL: www.aosong.com
+/*
+ * bit[7]: Busy
+ * bit[6:5]: 00: NOR mode, 01: CYC mode, 1x: CMD mode 
+ * bit[4]: Reserved
+ * bit[3]: CAL Enable
+ * bit[2:0]: Reserved
+*/
 
 //This means it's a primitive enum representation; aka uint8_t
 #[repr(u8)]


### PR DESCRIPTION
Found good way to use the embedded hal mocking crate to mock the delays needed for the device driver's init function.

Resolves #1 