### PR TITLE
Hal2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ embedded-hal = "0.2.7"
 [dev-dependencies]
 embedded-hal-mock = "0.9.0"
 
+#For future use: this will help with the transision from 0.2.7 --> 1.0.0
 #[patch.crates-io]
 #embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal", features = ["eh1"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub const BUSY_DELAY_MS: u16 = 20;
 pub const MEASURE_DELAY_MS: u16 = 80;
 pub const CALIBRATE_DELAY_MS: u16 = 10;
 
+//Number of attempts, an abitrary number.
 pub const MAX_ATTEMPTS: usize = 3;
 
 // Described by the datasheet as parameters.
@@ -281,10 +282,10 @@ mod sensor_test {
     fn calibrate()
     {
         let expectations = [
-            I2cTransaction::write(SENSOR_ADDR, vec![Command::Calibrate as u8, 0x08, 0x00]),
+            I2cTransaction::write(SENSOR_ADDR, vec![Command::Calibrate as u8, CAL_PARAM0, CAL_PARAM1]),
             I2cTransaction::write(SENSOR_ADDR, vec![Command::ReadStatus as u8]),
             I2cTransaction::read(SENSOR_ADDR, vec![sensor_status::BUSY_BM as u8]),
-            I2cTransaction::write(SENSOR_ADDR, vec![Command::Calibrate as u8, 0x08, 0x00]),
+            I2cTransaction::write(SENSOR_ADDR, vec![Command::Calibrate as u8, CAL_PARAM0, CAL_PARAM1]),
             I2cTransaction::write(SENSOR_ADDR, vec![Command::ReadStatus as u8]),
             I2cTransaction::read(SENSOR_ADDR, vec![sensor_status::CALENABLED_BM as u8]),
         ]; 
@@ -349,7 +350,7 @@ mod sensor_test {
             I2cTransaction::read(
                 SENSOR_ADDR, not_calibrated.clone()),
             I2cTransaction::write(
-                SENSOR_ADDR, vec![Command::Calibrate as u8, 0x08, 0x00]),
+                SENSOR_ADDR, vec![Command::Calibrate as u8, CAL_PARAM0, CAL_PARAM1]),
             I2cTransaction::write(
                 SENSOR_ADDR, vec![Command::ReadStatus as u8]),
             I2cTransaction::read(


### PR DESCRIPTION
This PR adds in rust docs info in the source code along with new impl methods on the sensor data structure.

These allow the use of 32bit floating point variables that we can fill with the 20bit sensor readings without losing information.
